### PR TITLE
Bugfix/#18 peer to peer api

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.wonjerry.wifi_connector'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.5.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -40,6 +40,6 @@ android {
 }
 
 dependencies {
-    implementation 'android.arch.lifecycle:common-java8:1.1.0'
+    implementation 'android.arch.lifecycle:common-java8:1.1.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,11 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.wonjerry.wifi_connector">
-
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="permissions:android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="permissions:android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,4 +3,6 @@
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="permissions:android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
 </manifest>

--- a/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
+++ b/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
@@ -91,7 +91,7 @@ class WifiConnectorPlugin : MethodCallHandler, FlutterPlugin {
         return;
       }
       disconnect()
-      enableNetwork(network.networkId, attemptConnect = true)
+      enableNetwork(network.networkId, true)
       reconnect()
       result.success(true)
     }

--- a/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
+++ b/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
@@ -87,7 +87,7 @@ class WifiConnectorPlugin : MethodCallHandler, FlutterPlugin, PluginRegistry.Act
         else -> result.notImplemented()
       }
     } catch (e: Exception) {
-      result.error("500", e.message, e.stackTrace)
+      result.error("500", e.message, e.stackTraceToString())
     }
   }
 

--- a/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
+++ b/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
@@ -82,13 +82,17 @@ class WifiConnectorPlugin : MethodCallHandler, FlutterPlugin {
       }
 
       // 위에서 생성한 configration을 추가하고 해당 네트워크와 연결한다.
-      val networkId = addNetwork(wifiConfiguration)
-      if (networkId == null || networkId == -1) {
+      addNetwork(wifiConfiguration)
+      val network = configuredNetworks.find { network ->
+        println(network.SSID)
+        network.SSID == ssid.wrapWithDoubleQuotes()
+      }
+      if (network == null) {
         result.success(false)
         return;
       }
       disconnect()
-      enableNetwork(networkId, true)
+      enableNetwork(network.networkId, attemptConnect = true)
       reconnect()
       result.success(true)
     }

--- a/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
+++ b/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
@@ -1,26 +1,60 @@
 package com.wonjerry.wifi_connector
 
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.net.Uri
 import android.net.wifi.WifiConfiguration
 import android.net.wifi.WifiManager
+import android.net.wifi.WifiNetworkSpecifier
+import android.net.wifi.WifiNetworkSuggestion
+import android.os.Build
+import android.os.Handler
+import android.provider.Settings
+import android.provider.Settings.ACTION_WIFI_ADD_NETWORKS
+import android.provider.Settings.EXTRA_WIFI_NETWORK_LIST
+import androidx.annotation.RequiresApi
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import io.flutter.plugin.common.PluginRegistry
 import io.flutter.plugin.common.PluginRegistry.Registrar
+import java.lang.Exception
 
-class WifiConnectorPlugin : MethodCallHandler, FlutterPlugin {
+class WifiConnectorPlugin : MethodCallHandler, FlutterPlugin, PluginRegistry.ActivityResultListener, ActivityAware {
   companion object {
+    const val MANAGE_SETTINGS_RESULT_CODE = 1001
+    const val ADD_WIFI_RESULT_CODE = 1002
     @JvmStatic
     fun registerWith(registrar: Registrar) {
       val instance = WifiConnectorPlugin()
+      instance.activity = registrar.activity()
       // activity의 context를 받아오기위해 FlutterPlugin을 상속받고, interfacee들을 구현한다.
       instance.onAttachedToEngine(registrar.context(), registrar.messenger())
+      registrar.addActivityResultListener(instance)
     }
   }
 
+  private var binding: ActivityPluginBinding? = null
+  private var activity: Activity? = null
+  private var networkCallback: ConnectivityManager.NetworkCallback? = null
+  private var result: Result? =null
+  private var suggestion: WifiNetworkSuggestion? =null
+  private val connectivityManager: ConnectivityManager by lazy(LazyThreadSafetyMode.NONE) {
+    activityContext?.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+  }
   private var activityContext: Context? = null
   private var methodChannel: MethodChannel? = null
 
@@ -44,58 +78,224 @@ class WifiConnectorPlugin : MethodCallHandler, FlutterPlugin {
     }
   }
 
-
   override fun onMethodCall(call: MethodCall, result: Result) {
-    when (call.method) {
-      "connectToWifi" -> connectToWifi(call, result)
-      else -> result.notImplemented()
+    try {
+      when (call.method) {
+        "connectToWifi" -> connectToWifi(call, result)
+        "hasPermission" -> hasPermission(call, result)
+        "openPermissionsScreen" -> openPermissionsScreen(call, result)
+        else -> result.notImplemented()
+      }
+    } catch (e: Exception) {
+      result.error("500", e.message, e.stackTrace)
     }
+  }
+
+  private fun hasPermission(call: MethodCall, result: Result) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      if (Settings.System.canWrite(activityContext)) {
+        result.success(true)
+        return
+      }
+    }
+    result.success(false)
+  }
+
+  private fun openPermissionsScreen(call: MethodCall, result: Result) {
+    val context = activityContext
+    if (context == null) {
+      result.error("500", "Activity Context is null", "")
+      return
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      this.result = result
+      val intent = Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS)
+      intent.data = Uri.parse("package:" + context.packageName)
+      intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+      activity?.startActivityForResult(intent, MANAGE_SETTINGS_RESULT_CODE)
+      return
+    }
+    result.success(true)
   }
 
   private fun connectToWifi(call: MethodCall, result: Result) {
     val argMap = call.arguments as Map<String, Any>
     val ssid = argMap["ssid"] as String
     val password = argMap["password"] as String?
+    val isWap2 = argMap["isWap2"] as Boolean
+    val isWap3 = argMap["isWap3"] as Boolean
+    val internetRequired = argMap["internetRequired"] as Boolean
 
-    // 비밀번호가 있냐 없냐에 따라 wifi configration을 설정한다.
-    val wifiConfiguration =
-            if (password == null) {
-              WifiConfiguration().apply {
-                SSID = ssid.wrapWithDoubleQuotes()
-                status = WifiConfiguration.Status.CURRENT
-                allowedKeyManagement.set(WifiConfiguration.KeyMgmt.NONE)
-              }
-            } else {
-              WifiConfiguration().apply {
-                SSID = ssid.wrapWithDoubleQuotes()
-                preSharedKey = password.wrapWithDoubleQuotes()
-                status = WifiConfiguration.Status.CURRENT
-                allowedKeyManagement.set(WifiConfiguration.KeyMgmt.WPA_PSK)
-              }
-            }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      if (internetRequired) {
+        connectToWifiPostQWithInternet(result, ssid, password, isWap2, isWap3)
+      } else {
+        connectToWifiPostQWithoutInternet(result, ssid, password, isWap2, isWap3)
+      }
+    } else {
+      connectToWifiPreQ(result, ssid, password)
+    }
+  }
 
+
+  @RequiresApi(Build.VERSION_CODES.Q)
+  private fun connectToWifiPostQWithInternet(result: Result, ssid: String, password: String?, isWap2: Boolean, isWap3: Boolean) {
+    val context = activityContext
+    if (context == null) {
+      result.error("500", "Activity Context is null", "")
+      return
+    }
+    val suggestion = WifiNetworkSuggestion.Builder()
+      .setSsid(ssid)
+      .apply {
+        password?.let {
+          if (isWap2) {
+            setWpa2Passphrase(it)
+          } else if(isWap3){
+            setWpa3Passphrase(it)
+          }
+        }
+      }
+      .build()
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      this.result = result
+      this.suggestion = suggestion
+      val intent = Intent(ACTION_WIFI_ADD_NETWORKS)
+      intent.putExtra(EXTRA_WIFI_NETWORK_LIST, arrayListOf(suggestion))
+      intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+      activity?.startActivityForResult(intent, ADD_WIFI_RESULT_CODE)
+      return
+    }
+    connectToWifiPostQWithSuggestion(context, suggestion, result)
+  }
+
+  @RequiresApi(Build.VERSION_CODES.Q)
+  private fun connectToWifiPostQWithSuggestion(context: Context, suggestion: WifiNetworkSuggestion, result: Result){
+    val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+    val status = wifiManager.addNetworkSuggestions(listOf(suggestion))
+    result.success(status == WifiManager.STATUS_NETWORK_SUGGESTIONS_SUCCESS)
+  }
+
+  @RequiresApi(Build.VERSION_CODES.Q)
+  private fun connectToWifiPostQWithoutInternet(result: Result, ssid: String, password: String?, isWap2: Boolean, isWap3: Boolean) {
+    val context = activityContext
+    if (context == null) {
+      result.error("500", "Activity Context is null", "")
+      return
+    }
+    val specifier = WifiNetworkSpecifier.Builder()
+      .setSsid(ssid)
+      .apply {
+        if (password != null) {
+          if (isWap2) {
+            setWpa2Passphrase(password)
+          } else if (isWap3) {
+            setWpa3Passphrase(password)
+          }
+        }
+      }
+      .build()
+    networkCallback?.let { connectivityManager.unregisterNetworkCallback(it) }
+    val request = NetworkRequest.Builder()
+      .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+      .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+      .setNetworkSpecifier(specifier)
+      .build()
+
+    networkCallback = object : ConnectivityManager.NetworkCallback() {
+      override fun onAvailable(network: Network) {
+        connectivityManager.bindProcessToNetwork(network)
+        result.success(true)
+        // cannot unregister callback here since it would disconnect form the network
+      }
+
+      override fun onUnavailable() {
+        result.success(false)
+        connectivityManager.unregisterNetworkCallback(this)
+        networkCallback = null
+      }
+    }
+
+    val handler = Handler(context.mainLooper)
+    connectivityManager.requestNetwork(request, networkCallback!!, handler)
+  }
+
+  @SuppressLint("MissingPermission")
+  @Suppress("DEPRECATION")
+  private fun connectToWifiPreQ(result: Result, ssid: String, password: String?) {
+    val wifiConfiguration = if (password == null) {
+      WifiConfiguration().apply {
+        SSID = ssid.wrapWithDoubleQuotes()
+        status = WifiConfiguration.Status.CURRENT
+        allowedKeyManagement.set(WifiConfiguration.KeyMgmt.NONE)
+      }
+    } else {
+      WifiConfiguration().apply {
+        SSID = ssid.wrapWithDoubleQuotes()
+        preSharedKey = password.wrapWithDoubleQuotes()
+        status = WifiConfiguration.Status.CURRENT
+        allowedKeyManagement.set(WifiConfiguration.KeyMgmt.WPA_PSK)
+      }
+    }
     val wifiManager = activityContext?.applicationContext?.getSystemService(Context.WIFI_SERVICE) as WifiManager
-
     with(wifiManager) {
       if (!isWifiEnabled) {
         isWifiEnabled = true
       }
-
-      // 위에서 생성한 configration을 추가하고 해당 네트워크와 연결한다.
-      addNetwork(wifiConfiguration)
-      val network = configuredNetworks.find { network ->
-        network.SSID == ssid.wrapWithDoubleQuotes()
+      var networkId = addNetwork(wifiConfiguration)
+      if (networkId != -1) {
+        val network = configuredNetworks.find { network -> network.SSID == ssid.wrapWithDoubleQuotes() }
+        network?.let { networkId = it.networkId }
       }
-      if (network == null) {
+      if (networkId != -1) {
         result.success(false)
-        return;
+        return
       }
       disconnect()
-      enableNetwork(network.networkId, true)
+      enableNetwork(networkId, true)
       reconnect()
       result.success(true)
     }
+  }
 
+  override fun onActivityResult(code: Int, resultCode: Int, data: Intent?): Boolean {
+    val result = result ?: return false;
+    val suggestion = suggestion ?: return false;
+    val context = activityContext ?: return false;
+    when (code) {
+        ADD_WIFI_RESULT_CODE -> {
+          if (resultCode == Activity.RESULT_OK){
+            result.success(true)
+          }
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            connectToWifiPostQWithSuggestion(context, suggestion, result)
+          } else {
+            result.success(false)
+          }
+        }
+        MANAGE_SETTINGS_RESULT_CODE -> {
+          result.success(resultCode == Activity.RESULT_OK)
+        }
+    }
+    return true
+  }
+
+  override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+    activity = binding.activity
+    binding.addActivityResultListener(this)
+    this.binding = binding
+  }
+
+  override fun onDetachedFromActivityForConfigChanges() {}
+
+  override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+    activity = binding.activity
+  }
+
+  override fun onDetachedFromActivity() {
+    activity = null
+    binding?.removeActivityResultListener(this)
   }
 }
 

--- a/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
+++ b/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
@@ -158,17 +158,23 @@ class WifiConnectorPlugin : MethodCallHandler, FlutterPlugin, ActivityAware {
       .setNetworkSpecifier(specifier)
       .build()
     val networkCallback = object : ConnectivityManager.NetworkCallback() {
+      var resultSent = false
+
       override fun onAvailable(network: Network) {
         super.onAvailable(network)
         connectivityManager.bindProcessToNetwork(network)
+        if (resultSent) return
         result.success(true)
+        resultSent = true
         // cannot unregister callback here since it would disconnect from the network
       }
 
       override fun onUnavailable() {
         super.onUnavailable()
-        result.success(false)
         cleanupNetworkCallback(this)
+        if (resultSent) return
+        resultSent = true
+        result.success(false)
       }
     }
     val handler = Handler(context.mainLooper)

--- a/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
+++ b/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
@@ -89,8 +89,8 @@ class WifiConnectorPlugin : MethodCallHandler, FlutterPlugin {
       }
       disconnect()
       enableNetwork(networkId, true)
-      reconnect()
-      result.success(true)
+      val connectionResult = reconnect()
+      result.success(connectionResult)
     }
 
   }

--- a/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
+++ b/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
@@ -82,15 +82,15 @@ class WifiConnectorPlugin : MethodCallHandler, FlutterPlugin {
       }
 
       // 위에서 생성한 configration을 추가하고 해당 네트워크와 연결한다.
-      var networkId = addNetwork(wifiConfiguration)
-      if (networkId == null) {
+      val networkId = addNetwork(wifiConfiguration)
+      if (networkId == null || networkId == -1) {
         result.success(false)
         return;
       }
       disconnect()
       enableNetwork(networkId, true)
-      val connectionResult = reconnect()
-      result.success(connectionResult)
+      reconnect()
+      result.success(true)
     }
 
   }

--- a/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
+++ b/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
@@ -196,11 +196,9 @@ class WifiConnectorPlugin : MethodCallHandler, FlutterPlugin, PluginRegistry.Act
     var isConnected = false
     while (!isConnected) {
       val wifiManager = context.getSystemService(Context.WIFI_SERVICE) as WifiManager
-      val connectedSsid =   wifiManager.connectionInfo.ssid
-      if (ssid == connectedSsid) {
-        Handler(context.mainLooper).post {
-          result.success(true)
-        }
+      val connectedSsid = wifiManager.connectionInfo.ssid
+      if ("\"$ssid\"" == connectedSsid || ssid == connectedSsid) {
+        result.success(true)
         isConnected = true
       }
     }
@@ -295,7 +293,6 @@ class WifiConnectorPlugin : MethodCallHandler, FlutterPlugin, PluginRegistry.Act
     val suggestion = suggestion ?: return false
     when (code) {
         ADD_WIFI_RESULT_CODE -> {
-          println(resultCode)
           if (resultCode != Activity.RESULT_OK) {
             result.success(false)
             return true

--- a/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
+++ b/android/src/main/kotlin/com/wonjerry/wifi_connector/WifiConnectorPlugin.kt
@@ -84,7 +84,6 @@ class WifiConnectorPlugin : MethodCallHandler, FlutterPlugin {
       // 위에서 생성한 configration을 추가하고 해당 네트워크와 연결한다.
       addNetwork(wifiConfiguration)
       val network = configuredNetworks.find { network ->
-        println(network.SSID)
         network.SSID == ssid.wrapWithDoubleQuotes()
       }
       if (network == null) {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -40,7 +40,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.wonjerry.wifi_connector_example"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:exported="true"
             android:hardwareAccelerated="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.5.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:wifi_connector/wifi_connector.dart';
 
@@ -14,6 +16,8 @@ class _MyAppState extends State<MyApp> {
   var _isSucceed = false;
   var _loading = false;
   var _hasPermission = false;
+  var _securityType = SecurityType.WPA2;
+  var _internetRequired = true;
 
   @override
   void initState() {
@@ -63,6 +67,26 @@ class _MyAppState extends State<MyApp> {
                 'password',
                 _passwordController,
               ),
+              if (Platform.isAndroid)
+                SwitchListTile(
+                  title: Text('Internet Required'),
+                  value: _internetRequired,
+                  onChanged: (value) {
+                    setState(() {
+                      _internetRequired = value;
+                    });
+                  },
+                ),
+              for (final item in SecurityType.values)
+                ListTile(
+                  title: Text(item.toString()),
+                  onTap: () => _onSecurityTypeChanged(item),
+                  leading: Radio<SecurityType>(
+                    value: item,
+                    groupValue: _securityType,
+                    onChanged: (value) => _onSecurityTypeChanged(item),
+                  ),
+                ),
               Padding(
                 padding: const EdgeInsets.only(top: 24.0),
                 child: ElevatedButton(
@@ -70,17 +94,7 @@ class _MyAppState extends State<MyApp> {
                     'connect',
                     style: TextStyle(color: Colors.white),
                   ),
-                  onPressed: () => _onConnectPressed(internetRequired: true),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(top: 24.0),
-                child: ElevatedButton(
-                  child: Text(
-                    'connect without internet',
-                    style: TextStyle(color: Colors.white),
-                  ),
-                  onPressed: () => _onConnectPressed(internetRequired: false),
+                  onPressed: _onConnectPressed,
                 ),
               ),
               Text(
@@ -116,7 +130,7 @@ class _MyAppState extends State<MyApp> {
     );
   }
 
-  Future<void> _onConnectPressed({required bool internetRequired}) async {
+  Future<void> _onConnectPressed() async {
     final ssid = _ssidController.text;
     final password = _passwordController.text;
     setState(() {
@@ -127,8 +141,8 @@ class _MyAppState extends State<MyApp> {
       final isSucceed = await WifiConnector.connectToWifi(
         ssid: ssid,
         password: password,
-        internetRequired: internetRequired,
-        securityType: SecurityType.WPA2,
+        internetRequired: _internetRequired,
+        securityType: _securityType,
       );
       _isSucceed = isSucceed;
     } catch (e, stack) {
@@ -146,5 +160,11 @@ class _MyAppState extends State<MyApp> {
   Future<void> _checkPermission() async {
     final hasPermission = await WifiConnector.hasPermission();
     setState(() => _hasPermission = hasPermission);
+  }
+
+  void _onSecurityTypeChanged(SecurityType item) {
+    setState(() {
+      _securityType = item;
+    });
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -120,7 +120,7 @@ class _MyAppState extends State<MyApp> {
       final isSucceed = await WifiConnector.connectToWifi(
         ssid: ssid,
         password: password,
-        securityType: SecurityType.WAP2,
+        securityType: SecurityType.WPA2,
       );
       _isSucceed = isSucceed;
     } catch (e, stack) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,4 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
-
 import 'package:wifi_connector/wifi_connector.dart';
 
 void main() => runApp(MyApp());
@@ -73,7 +70,17 @@ class _MyAppState extends State<MyApp> {
                     'connect',
                     style: TextStyle(color: Colors.white),
                   ),
-                  onPressed: _onConnectPressed,
+                  onPressed: () => _onConnectPressed(internetRequired: true),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(top: 24.0),
+                child: ElevatedButton(
+                  child: Text(
+                    'connect without internet',
+                    style: TextStyle(color: Colors.white),
+                  ),
+                  onPressed: () => _onConnectPressed(internetRequired: false),
                 ),
               ),
               Text(
@@ -109,7 +116,7 @@ class _MyAppState extends State<MyApp> {
     );
   }
 
-  Future<void> _onConnectPressed() async {
+  Future<void> _onConnectPressed({required bool internetRequired}) async {
     final ssid = _ssidController.text;
     final password = _passwordController.text;
     setState(() {
@@ -120,13 +127,16 @@ class _MyAppState extends State<MyApp> {
       final isSucceed = await WifiConnector.connectToWifi(
         ssid: ssid,
         password: password,
+        internetRequired: internetRequired,
         securityType: SecurityType.WPA2,
       );
       _isSucceed = isSucceed;
     } catch (e, stack) {
       print('Error: $e\n$stack');
     }
-    setState(() => _loading = false);
+    setState(() {
+      _loading = false;
+    });
   }
 
   Future<void> _onHasPermissionClicked() => _checkPermission();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -116,11 +116,13 @@ class _MyAppState extends State<MyApp> {
       _isSucceed = false;
       _loading = true;
     });
-    final isSucceed = await WifiConnector.connectToWifi(ssid: ssid, password: password, securityType: SecurityType.WAP3);
-    setState(() {
+    try{
+      final isSucceed = await WifiConnector.connectToWifi(ssid: ssid, password: password, securityType: SecurityType.WAP3);
       _isSucceed = isSucceed;
-      _loading = false;
-    });
+    } catch(e, stack) {
+      print('Error: $e\n$e');
+    }
+    setState(() => _loading = false);
   }
 
   Future<void> _onHasPermissionClicked() => _checkPermission();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -116,21 +116,22 @@ class _MyAppState extends State<MyApp> {
       _isSucceed = false;
       _loading = true;
     });
-    try{
-      final isSucceed = await WifiConnector.connectToWifi(ssid: ssid, password: password, securityType: SecurityType.WAP3);
+    try {
+      final isSucceed = await WifiConnector.connectToWifi(
+        ssid: ssid,
+        password: password,
+        securityType: SecurityType.WAP2,
+      );
       _isSucceed = isSucceed;
-    } catch(e, stack) {
-      print('Error: $e\n$e');
+    } catch (e, stack) {
+      print('Error: $e\n$stack');
     }
     setState(() => _loading = false);
   }
 
   Future<void> _onHasPermissionClicked() => _checkPermission();
 
-  Future<void> _onRequestPermissionClicked() async {
-    final hasPermission = await WifiConnector.openPermissionsScreen();
-    setState(() => _hasPermission = hasPermission);
-  }
+  Future<void> _onRequestPermissionClicked() => WifiConnector.openPermissionsScreen();
 
   Future<void> _checkPermission() async {
     final hasPermission = await WifiConnector.hasPermission();

--- a/ios/Classes/SwiftWifiConnectorPlugin.swift
+++ b/ios/Classes/SwiftWifiConnectorPlugin.swift
@@ -23,14 +23,14 @@ public class SwiftWifiConnectorPlugin: NSObject, FlutterPlugin {
     // Flutter 쪽에서 arguments로 map을 보낸 것을 이렇게 Dictionary로 parsing해서 사용한다.
     guard let argMaps = call.arguments as? Dictionary<String, Any>,
       let ssid = argMaps["ssid"] as? String,
-      let isWEP = argMaps["isWEP"] as? Bool else {
+      let isWEP = argMaps["isWep"] as? Bool else {
         result(FlutterError(code: call.method, message: "Missing arguments", details: nil))
         return
     }
     
     var hotspotConfiguration: NEHotspotConfiguration
     
-    if isWEP {
+    if isWep {
       result(FlutterError(code: call.method, message: "WEP is not supported", details: nil))
       return
     }

--- a/ios/Classes/SwiftWifiConnectorPlugin.swift
+++ b/ios/Classes/SwiftWifiConnectorPlugin.swift
@@ -23,7 +23,7 @@ public class SwiftWifiConnectorPlugin: NSObject, FlutterPlugin {
     // Flutter 쪽에서 arguments로 map을 보낸 것을 이렇게 Dictionary로 parsing해서 사용한다.
     guard let argMaps = call.arguments as? Dictionary<String, Any>,
       let ssid = argMaps["ssid"] as? String,
-      let isWEP = argMaps["isWep"] as? Bool else {
+      let isWep = argMaps["isWep"] as? Bool else {
         result(FlutterError(code: call.method, message: "Missing arguments", details: nil))
         return
     }

--- a/ios/Classes/SwiftWifiConnectorPlugin.swift
+++ b/ios/Classes/SwiftWifiConnectorPlugin.swift
@@ -24,7 +24,7 @@ public class SwiftWifiConnectorPlugin: NSObject, FlutterPlugin {
     guard let argMaps = call.arguments as? Dictionary<String, Any>,
       let ssid = argMaps["ssid"] as? String,
       let isWEP = argMaps["isWEP"] as? Bool else {
-        result(FlutterError(code: call.method, message: "Missing argument: ssid", details: nil))
+        result(FlutterError(code: call.method, message: "Missing arguments", details: nil))
         return
     }
     

--- a/ios/Classes/SwiftWifiConnectorPlugin.swift
+++ b/ios/Classes/SwiftWifiConnectorPlugin.swift
@@ -20,7 +20,6 @@ public class SwiftWifiConnectorPlugin: NSObject, FlutterPlugin {
   }
   
   private func connectToWifi(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
-    // Flutter 쪽에서 arguments로 map을 보낸 것을 이렇게 Dictionary로 parsing해서 사용한다.
     guard let argMaps = call.arguments as? Dictionary<String, Any>,
       let ssid = argMaps["ssid"] as? String,
       let isWep = argMaps["isWep"] as? Bool else {
@@ -29,21 +28,14 @@ public class SwiftWifiConnectorPlugin: NSObject, FlutterPlugin {
     }
     
     var hotspotConfiguration: NEHotspotConfiguration
-    
-    if isWep {
-      result(FlutterError(code: call.method, message: "WEP is not supported", details: nil))
-      return
-    }
-    
     if let password = argMaps["password"] as? String {
-      hotspotConfiguration = NEHotspotConfiguration(ssid: ssid, passphrase: password, isWEP: false)
+      hotspotConfiguration = NEHotspotConfiguration(ssid: ssid, passphrase: password, isWEP: isWep)
     } else {
       hotspotConfiguration = NEHotspotConfiguration(ssid: ssid)
     }
     
     hotspotConfiguration.lifeTimeInDays = 1
     
-    // 연결을 시도하고, 성공 여부를 callback으로 전달받는다.
     NEHotspotConfigurationManager.shared.apply(hotspotConfiguration) { (error) in
       guard let error = error else {
         result(true)

--- a/lib/wifi_connector.dart
+++ b/lib/wifi_connector.dart
@@ -9,7 +9,11 @@ class WifiConnector {
   /// Connect to wifi with the native platform api's
   /// Security type
   ///   Android: Supported WPA2/WPA3
-  ///   iOS: Supported WPA2
+  ///   iOS: Supported WEP/WPA2
+  /// internetRequired: true
+  ///   Android: This will use the `peer-to-peer` API. You will not see that you are connected to an other network. but you can configure your device with this API.
+  ///            Mostly used for IOT device setup. Chomecast/IOT/Router/Gateway/...
+  ///   iOS: Will use the same API when set to true or false. (connect to wifi network with internet connectivity if possible)
   static Future<bool> connectToWifi({required String ssid, String? password, SecurityType securityType = SecurityType.NONE, bool internetRequired = true}) async {
     if (password != null && securityType == SecurityType.NONE) {
       throw ArgumentError('If you are using a password you should also set the correct securityType');
@@ -36,7 +40,7 @@ class WifiConnector {
 
   /// Open the permission screen
   /// Android only required Android 10+
-  /// iOS will always return true because there is no permission needed & no screen will be opened
+  /// iOS will be a no-op because there are no permissions needed for iOS
   static Future<void> openPermissionsScreen() async {
     if (Platform.isIOS) return;
     await _channel.invokeMethod<bool>('openPermissionsScreen');

--- a/lib/wifi_connector.dart
+++ b/lib/wifi_connector.dart
@@ -11,6 +11,9 @@ class WifiConnector {
   ///   Android: Supported WAP2/WAP3
   ///   iOS: Supported WAP2
   static Future<bool> connectToWifi({required String ssid, String? password, SecurityType securityType = SecurityType.NONE, bool internetRequired = true}) async {
+    if (password != null && securityType == SecurityType.NONE) {
+      throw ArgumentError('If you are using a password you should also set the correct securityType');
+    }
     final result = await _channel.invokeMethod<bool>('connectToWifi', {
       'ssid': ssid,
       'password': password,

--- a/lib/wifi_connector.dart
+++ b/lib/wifi_connector.dart
@@ -1,16 +1,50 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/services.dart';
 
 class WifiConnector {
   static const MethodChannel _channel = const MethodChannel('wifi_connector');
 
-  static Future<bool> connectToWifi({required String ssid, String? password, bool isWEP = false}) async {
+  /// Connect to wifi with the native platform api's
+  /// Security type
+  ///   Android: Supported WAP2/WAP3
+  ///   iOS: Supported WAP2
+  static Future<bool> connectToWifi({required String ssid, String? password, SecurityType securityType = SecurityType.NONE, bool internetRequired = true}) async {
     final result = await _channel.invokeMethod<bool>('connectToWifi', {
       'ssid': ssid,
       'password': password,
-      'isWEP': isWEP,
+      'isWEP': securityType == SecurityType.WEP,
+      'isWap2': securityType == SecurityType.WAP2,
+      'isWap3': securityType == SecurityType.WAP3,
+      'internetRequired': internetRequired,
     });
+    print('RESULT: $result');
     return result == true;
   }
+
+  /// Check if your app already has permission to update the wifi settings
+  /// Android only required Android 10+
+  /// iOS will always return true because there is no permission needed
+  static Future<bool> hasPermission() async {
+    if (Platform.isIOS) return true;
+    final result = await _channel.invokeMethod<bool>('hasPermission');
+    return result == true;
+  }
+
+  /// Open the permission screen
+  /// Android only required Android 10+
+  /// iOS will always return true because there is no permission needed & no screen will be opened
+  static Future<bool> openPermissionsScreen() async {
+    if (Platform.isIOS) return true;
+    await _channel.invokeMethod<bool>('openPermissionsScreen');
+    return hasPermission();
+  }
+}
+
+enum SecurityType {
+  NONE,
+  WEP,
+  WAP2,
+  WAP3,
 }

--- a/lib/wifi_connector.dart
+++ b/lib/wifi_connector.dart
@@ -8,8 +8,8 @@ class WifiConnector {
 
   /// Connect to wifi with the native platform api's
   /// Security type
-  ///   Android: Supported WAP2/WAP3
-  ///   iOS: Supported WAP2
+  ///   Android: Supported WPA2/WPA3
+  ///   iOS: Supported WPA2
   static Future<bool> connectToWifi({required String ssid, String? password, SecurityType securityType = SecurityType.NONE, bool internetRequired = true}) async {
     if (password != null && securityType == SecurityType.NONE) {
       throw ArgumentError('If you are using a password you should also set the correct securityType');
@@ -18,8 +18,8 @@ class WifiConnector {
       'ssid': ssid,
       'password': password,
       'isWEP': securityType == SecurityType.WEP,
-      'isWap2': securityType == SecurityType.WAP2,
-      'isWap3': securityType == SecurityType.WAP3,
+      'isWpa2': securityType == SecurityType.WPA2,
+      'isWpa3': securityType == SecurityType.WPA3,
       'internetRequired': internetRequired,
     });
     print('RESULT: $result');
@@ -47,6 +47,6 @@ class WifiConnector {
 enum SecurityType {
   NONE,
   WEP,
-  WAP2,
-  WAP3,
+  WPA2,
+  WPA3,
 }

--- a/lib/wifi_connector.dart
+++ b/lib/wifi_connector.dart
@@ -22,7 +22,6 @@ class WifiConnector {
       'isWpa3': securityType == SecurityType.WPA3,
       'internetRequired': internetRequired,
     });
-    print('RESULT: $result');
     return result == true;
   }
 

--- a/lib/wifi_connector.dart
+++ b/lib/wifi_connector.dart
@@ -38,10 +38,9 @@ class WifiConnector {
   /// Open the permission screen
   /// Android only required Android 10+
   /// iOS will always return true because there is no permission needed & no screen will be opened
-  static Future<bool> openPermissionsScreen() async {
-    if (Platform.isIOS) return true;
+  static Future<void> openPermissionsScreen() async {
+    if (Platform.isIOS) return;
     await _channel.invokeMethod<bool>('openPermissionsScreen');
-    return hasPermission();
   }
 }
 

--- a/lib/wifi_connector.dart
+++ b/lib/wifi_connector.dart
@@ -17,7 +17,7 @@ class WifiConnector {
     final result = await _channel.invokeMethod<bool>('connectToWifi', {
       'ssid': ssid,
       'password': password,
-      'isWEP': securityType == SecurityType.WEP,
+      'isWep': securityType == SecurityType.WEP,
       'isWpa2': securityType == SecurityType.WPA2,
       'isWpa3': securityType == SecurityType.WPA3,
       'internetRequired': internetRequired,

--- a/test/wifi_connector_test.dart
+++ b/test/wifi_connector_test.dart
@@ -18,7 +18,9 @@ void main() {
   test('getPlatformVersion', () async {
     expect(
         await WifiConnector.connectToWifi(
-            ssid: 'myssid', password: 'mypassword'),
+          ssid: 'myssid',
+          password: 'mypassword',
+        ),
         true);
   });
 }


### PR DESCRIPTION
Fixed #18 

Known bugs with this implementation:

~- [] sometimes, after connecting. And trying a second time to connect. You immediately get a result: true But you still get a dialog that want to connect to the same wifi. When accepting that dialog the connection process begins. And if it succeeds you get a fatal crash, because the flutter result was already used. `Result already submitted`~
-> This bug was fixed by adding a separate disconnect method & using a resultSent variable on the NetworkCallback

Please provide feedback on the new api's & method names. If they could be improved let me know. 