### PR TITLE
Updated Kotlin version in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.wonjerry.wifi_connector'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.3.40'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
For fixing this errror: The Android Gradle plugin supports only Kotlin Gradle plugin version 1.3.40 and higher. The following dependencies do not satisfy the required version: project ':wifi_connector' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.31